### PR TITLE
Updated Solution to Lists Exercise 3

### DIFF
--- a/01-lesson_notebooks/06c-Exercise_Solutions.ipynb
+++ b/01-lesson_notebooks/06c-Exercise_Solutions.ipynb
@@ -150,10 +150,21 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['eno', 'owt', 'eerht']"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "def rev_string_list(string_list: list[str]) -> str:\n",
-    "    return [string_list[::-1] for s in string_list]"
+    "def rev_string_list(string_list: list[str]) -> list[str]:\n",
+    "    return [s[::-1] for s in string_list]"
    ]
   },
   {
@@ -200,7 +211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.12.6"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Updated solution to Lists Exercise 3: Write a function named rev_string_list that takes as a parameter a list of strings and returns a list that contains the reverse of each of those strings. Use a list comprehension.

Old solution would take argument list of [one, two, three] and return:
[three, two, one], [three, two, one], [three, two, one] because list comprehension was iterating through the entire list and reversing it a number of times equal to the length of the list.

New solution returns [eno, owt, eerht] since the comprehension works through each element of the list and reverses its order, not the order of the list itself.